### PR TITLE
bug: deprecated removeEventListener()

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     },
     "dependencies": {
         "react-native-animatable": "^1.3.1",
-        "react-native-modal": "^11.3.1",
+        "react-native-modal": "^13.0.0",
         "standard-version": "^9.3.1"
     },
     "devDependencies": {
-        "react": "16.8.3",
-        "react-native": "0.59.8"
+        "react": ">=17.0.2",
+        "react-native": ">=0.65.0"
     }
 }

--- a/src/CustomisableAlert.js
+++ b/src/CustomisableAlert.js
@@ -34,7 +34,7 @@ export default class CustomisableAlert extends Component {
 
     componentDidMount() {
         AlertManager.register(this);
-        Dimensions.addEventListener('change', ({ screen }) => {
+        this.dimensionsSubscription = Dimensions.addEventListener('change', ({ screen }) => {
             this.setState({
                 screenHeight: screen.height,
                 screenWidth: screen.width
@@ -44,7 +44,7 @@ export default class CustomisableAlert extends Component {
 
     componentWillUnmount() {
         AlertManager.unregister(this);
-        Dimensions.removeEventListener('change')
+        this.dimensionsSubscription?.remove();
     }
 
     showAlert = ({


### PR DESCRIPTION
I've found that the method removeEventListener() crashed whenever it was called, and according to RN documentation in versions greater than v0.65+ this method was deprecated. I decided to make this PR to add support for new RN versions. I might be missing some things, but I've checked with an app I am developing for RN 0.70 and it worked fine.

I'll attach some information I've found and used regarding this issue.
[React Native: Dimensions Docs](https://reactnative.dev/docs/dimensions#addeventlistener)
[react-native-modal similar issue](https://github.com/react-native-modal/react-native-modal/pull/594)
[React upgrade versions](https://react-native-community.github.io/upgrade-helper/?from=0.59.8&to=0.65.0)